### PR TITLE
UDP with initContainer assess

### DIFF
--- a/conntrack_test.go
+++ b/conntrack_test.go
@@ -1,0 +1,163 @@
+package suites
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/k8sbykeshed/k8s-service-lb-validator/entities"
+	"github.com/k8sbykeshed/k8s-service-lb-validator/entities/kubernetes"
+	"github.com/k8sbykeshed/k8s-service-lb-validator/matrix"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+var (
+	udpPort          int32 = 80
+	udpNamespaceName string
+)
+
+// podUDPStaleServer returns server pod spec
+func podUDPStaleServer(podName string, node *v1.Node) (*entities.Pod, error) {
+	pod := &entities.Pod{
+		Name:      podName,
+		Namespace: udpNamespaceName,
+		InitContainers: []*entities.Container{{
+			Command: []string{"/bin/sh", "-c", "echo Pausing start. && sleep 10"},
+		}},
+		Containers: []*entities.Container{
+			{Port: udpPort, Protocol: v1.ProtocolUDP},
+		},
+		NodeName: node.Name,
+	}
+
+	if _, err := ma.CreatePod(pod.ToK8SSpec()); err != nil {
+		return nil, err
+	}
+	if err := ma.WaitAndSetIPs(pod); err != nil {
+		return nil, err
+	}
+
+	return pod, nil
+}
+
+// podUDPStaleClient returns client pod spec
+func podUDPStaleClient(podName, clusterIP string, node *v1.Node) (*entities.Pod, error) {
+	cmd := fmt.Sprintf(`date; for i in $(seq 1 3000); do echo "$(date) Try: ${i}"; echo hostname | nc -u -w2 %s %d; echo; done`, clusterIP, udpPort)
+	pod := &entities.Pod{
+		SkipProbe: true,
+		Name:      podName,
+		NodeName:  node.Name,
+		Namespace: udpNamespaceName,
+		Containers: []*entities.Container{
+			{Protocol: v1.ProtocolUDP, Port: 80},
+			{Image: "busybox", Command: []string{"/bin/sh", "-c", cmd}},
+		},
+	}
+
+	if _, err := ma.CreatePod(pod.ToK8SSpec()); err != nil {
+		return nil, err
+	}
+	if err := ma.WaitAndSetIPs(pod); err != nil {
+		return nil, err
+	}
+
+	return pod, nil
+}
+
+// 1. Create an UDP Service
+// 2. Client Pod sending traffic to the UDP service
+// 3. Create an UDP server associated to the Service created in 1. with an init container that sleeps for some time
+// The init container makes that the server pod is not ready, however, the endpoint slices are created, it is just
+// that the Endpoint conditions Ready is false.
+func TestUDPInitContainer(t *testing.T) {
+	var (
+		udpModel matrix.Model
+		services kubernetes.Services
+	)
+
+	featureUDPInitContainer := features.New("UDP stale endpoint").WithLabel("type", "udp_stale_endpoint").
+		Setup(func(context.Context, *testing.T, *envconf.Config) context.Context {
+			var (
+				err                 error
+				result              bool
+				scheduledNodes      []*v1.Node
+				firstPod, secondPod *entities.Pod
+			)
+
+			// create and start namespace and ready nodes
+			udpNamespaceName = matrix.GetNamespace()
+			udpNamespace := entities.Namespace{Name: udpNamespaceName}
+			if _, err := ma.CreateNamespace(udpNamespace.Spec()); err != nil {
+				t.Fatal(err)
+			}
+			if scheduledNodes, err = ma.GetReadyNodes(); err != nil {
+				t.Fatal(err)
+			}
+
+			// create stale server pod
+			if firstPod, err = podUDPStaleServer("pod-1", scheduledNodes[0]); err != nil {
+				t.Fatal(err)
+			}
+
+			// create a cluster service based on backend server
+			clusterSvc := firstPod.ClusterIPService()
+			var service kubernetes.ServiceBase = kubernetes.NewService(cs, clusterSvc)
+			if _, err := service.Create(); err != nil {
+				t.Fatal(err)
+			}
+			var clusterIP string
+			// wait for final status
+			if result, err = service.WaitForEndpoint(); err != nil || !result {
+				t.Fatal(errors.New("no endpoint available"))
+			}
+			if clusterIP, err = service.WaitForClusterIP(); err != nil || clusterIP == "" {
+				t.Fatal(errors.New("no cluster IP available"))
+			}
+
+			firstPod.SetClusterIP(clusterIP)
+			services = append(services, service.(*kubernetes.Service))
+
+			// Create a pod in one node to create the UDP traffic against the ClusterIP service every 5 seconds
+			// start a stale connection without marking stale creates a wrong conn track entry
+			// invalidating the NAT cache
+			if secondPod, err = podUDPStaleClient("pod-2", clusterIP, scheduledNodes[1]); err != nil {
+				t.Fatal(err)
+			}
+
+			// start the model with the namespace
+			udpNamespace.Pods = []*entities.Pod{firstPod, secondPod}
+			udpModel = *matrix.NewModelWithNamespace([]*entities.Namespace{&udpNamespace}, dnsDomain)
+
+			return ctx
+		}).
+		Teardown(func(context.Context, *testing.T, *envconf.Config) context.Context {
+			logger.Info("Cleanup namespace.")
+			if err := ma.DeleteNamespaces([]string{udpNamespaceName}); err != nil {
+				t.Fatal(err)
+			}
+			return ctx
+		}).
+		Assess("should be reachable", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			ma.Logger.Info("Creating UDP and conntrack entries")
+			reachability := matrix.NewReachability(udpModel.AllPods(), true)
+
+			// Note that the fact that Endpoints object already exists, does NOT mean
+			// that iptables (or whatever else is used) was already programmed.
+			// Additionally take into account that UDP conntract entries timeout is
+			// 30 seconds by default.
+			// Based on the above check if the pod receives the traffic.
+
+			testCase := matrix.TestCase{ToPort: 80, Protocol: v1.ProtocolUDP, Reachability: reachability, ServiceType: entities.ClusterIP}
+			wrong := matrix.ValidateOrFail(ma, &udpModel, &testCase, false)
+			if wrong > 0 {
+				t.Error("Wrong result number ")
+			}
+			return ctx
+		}).Feature()
+
+	testenv.Test(t, featureUDPInitContainer)
+}

--- a/entities/container.go
+++ b/entities/container.go
@@ -2,7 +2,9 @@ package entities
 
 import (
 	"fmt"
+	"math/rand"
 	"strings"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 )
@@ -10,37 +12,48 @@ import (
 // AgnhostImage is the image reference
 const AgnhostImage = "k8s.gcr.io/e2e-test-images/agnhost:2.31"
 
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
 // Container represents the container model
 type Container struct {
+	Name     string
+	Image    string
 	Command  []string
 	Protocol v1.Protocol
 	Port     int32
 }
 
-// NewContainer returns a new internal container
-func NewContainer(port int32, protocol v1.Protocol, cmd []string) *Container {
-	return &Container{
-		Command:  cmd,
-		Protocol: protocol,
-		Port:     port,
+// GetName returns the parsed container name
+func (c *Container) GetName() string {
+	rand.Seed(time.Now().UnixNano())
+	if c.Name == "" {
+		if c.Port == 0 {
+			c.Name = fmt.Sprintf("cont-%d", rand.Intn(1e5))
+		} else {
+			c.Name = fmt.Sprintf("cont-%d-%s", c.Port, strings.ToLower(string(c.Protocol)))
+		}
 	}
-}
-
-// Name returns the parsed container name
-func (c *Container) Name() string {
-	return fmt.Sprintf("cont-%d-%s", c.Port, strings.ToLower(string(c.Protocol)))
+	return c.Name
 }
 
 //
 // PortName returns the parsed container port name
 func (c *Container) PortName() string {
+	if c.Port == 0 {
+		return fmt.Sprintf("serve-%d", rand.Intn(1e5))
+	}
 	return fmt.Sprintf("serve-%d-%s", c.Port, strings.ToLower(string(c.Protocol)))
 }
 
 // ToK8SSpec returns the Kubernetes container specification
 func (c *Container) ToK8SSpec() v1.Container {
-	var cmd = c.Command
-
+	var (
+		cmd   = c.Command
+		name  = c.GetName()
+		image = AgnhostImage
+	)
 	if len(cmd) == 0 {
 		switch c.Protocol {
 		case v1.ProtocolTCP:
@@ -51,19 +64,25 @@ func (c *Container) ToK8SSpec() v1.Container {
 			fmt.Println(fmt.Printf("invalid protocol %v", c.Protocol))
 		}
 	}
-
+	if c.Image != "" {
+		image = c.Image
+	}
 	// it must have a container/port tuple per container
-	return v1.Container{
-		Name:            c.Name(),
-		Image:           AgnhostImage,
+	container := v1.Container{
+		Name:            name,
 		ImagePullPolicy: v1.PullIfNotPresent,
-		Ports: []v1.ContainerPort{
+		Image:           image,
+		Command:         cmd,
+	}
+	if c.Port > 0 {
+		container.Ports = []v1.ContainerPort{
 			{
 				ContainerPort: c.Port,
 				Name:          c.PortName(),
 				Protocol:      c.Protocol,
 			},
-		},
-		Command: cmd,
+		}
 	}
+
+	return container
 }

--- a/entities/kubernetes/exec.go
+++ b/entities/kubernetes/exec.go
@@ -19,7 +19,8 @@ import (
 )
 
 const (
-	poll = 10 * time.Second
+	poll    = 10 * time.Second
+	timeout = 1 * time.Minute
 )
 
 var errPodCompleted = fmt.Errorf("pod ran to completion")
@@ -30,7 +31,6 @@ func WaitForPodRunningInNamespace(c *kubernetes.Clientset, pod *v1.Pod) error {
 	if pod.Status.Phase == v1.PodRunning {
 		return nil
 	}
-	timeout := 5 * time.Minute
 	return wait.PollImmediate(poll, timeout, podRunning(c, pod.Name, pod.Namespace))
 }
 
@@ -74,7 +74,7 @@ type ExecOptions struct {
 // ExecWithOptions executes a command in the specified container,
 // returning stdout, stderr and error. `options` allowed for
 // additional parameters to be passed.
-func ExecWithOptions(config *rest.Config, cs *kubernetes.Clientset, options *ExecOptions) (string, string, error) {
+func ExecWithOptions(config *rest.Config, cs *kubernetes.Clientset, options *ExecOptions) (string, string, error) {  // nolint
 	tty := false
 	req := cs.CoreV1().RESTClient().Post().
 		Resource("pods").

--- a/entities/service.go
+++ b/entities/service.go
@@ -21,6 +21,7 @@ const (
 
 // serviceID prevent conflicts when creating multiple services for same pod
 var serviceID int
+
 // NewService returns the service boilerplate
 func NewService(p *Pod) *v1.Service {
 	serviceID++
@@ -37,7 +38,7 @@ func NewService(p *Pod) *v1.Service {
 
 // portFromContainer is a helper to return port spec from the service
 func portFromContainer(containers []*Container, protocol v1.Protocol) []v1.ServicePort {
-	var portsSet = map[v1.ServicePort]bool{}
+	portsSet := map[v1.ServicePort]bool{}
 	for _, container := range containers {
 		if protocol != Allprotocols && protocol != container.Protocol {
 			continue
@@ -50,7 +51,7 @@ func portFromContainer(containers []*Container, protocol v1.Protocol) []v1.Servi
 		portsSet[sp] = true
 	}
 
-	var ports []v1.ServicePort
+	var ports []v1.ServicePort  // nolint
 	for p := range portsSet {
 		ports = append(ports, p)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -3,14 +3,15 @@ package suites
 import (
 	"context"
 	"fmt"
-	"go.uber.org/zap/zapcore"
 	"log"
 	"os"
 	"testing"
 
+	"go.uber.org/zap/zapcore"
+	v1 "k8s.io/api/core/v1"
+
 	"github.com/k8sbykeshed/k8s-service-lb-validator/matrix"
 	"go.uber.org/zap"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
@@ -18,7 +19,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
 
-const DNSDomain = "cluster.local"
+const dnsDomain = "cluster.local"
 
 var (
 	namespace string
@@ -46,7 +47,7 @@ func NewLoggerConfig(options ...zap.Option) *zap.Logger {
 		EncodeDuration: zapcore.StringDurationEncoder,
 	}
 	// todo(knabben) - flag to enable debugging level
-	core := zapcore.NewCore(zapcore.NewConsoleEncoder(encoderCfg), os.Stdout, zap.InfoLevel)
+	core := zapcore.NewCore(zapcore.NewConsoleEncoder(encoderCfg), os.Stdout, zap.DebugLevel)
 	return zap.New(core).WithOptions(options...)
 }
 
@@ -82,7 +83,7 @@ func TestMain(m *testing.M) {
 			}
 
 			// Initialize environment pods model and cluster.
-			model = matrix.NewModel([]string{namespace}, pods, []int32{80, 81}, []v1.Protocol{v1.ProtocolTCP, v1.ProtocolUDP}, DNSDomain)
+			model = matrix.NewModel([]string{namespace}, pods, []int32{80, 81}, []v1.Protocol{v1.ProtocolTCP, v1.ProtocolUDP}, dnsDomain)
 			if err = ma.StartPods(model, nodes); err != nil {
 				log.Fatal(err)
 			}

--- a/matrix/helper.go
+++ b/matrix/helper.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
+
 	"go.uber.org/zap"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -59,4 +61,23 @@ func ValidateOrFail(k8s *KubeManager, model *Model, testCase *TestCase, ignoreLo
 		k8s.Logger.Info("Tests passed, validation succeeded!")
 	}
 	return wrong
+}
+
+// todo(knabben) - make a generic in slice contains function
+func protocolOnSlice(value v1.Protocol, slice []v1.Protocol) bool {
+	for _, item := range slice {
+		if item == value {
+			return true
+		}
+	}
+	return false
+}
+
+func intOnSlice(value int32, slice []int32) bool {
+	for _, item := range slice {
+		if item == value {
+			return true
+		}
+	}
+	return false
 }

--- a/matrix/reachability.go
+++ b/matrix/reachability.go
@@ -2,6 +2,7 @@ package matrix
 
 import (
 	"fmt"
+
 	"github.com/k8sbykeshed/k8s-service-lb-validator/entities"
 
 	v1 "k8s.io/api/core/v1"


### PR DESCRIPTION
1. Adding UDP with `initContainer` tests

This test creates a new environment with 2 pods only (allocating in the first available 2 nodes), the first Pod has a service and an `initContainer` that sleeps for 15 seconds before being available, the second pod keep requesting the first server pod via the ClusterIP and is expected the communication to be working after the first pod gets ready.

2. Fixing linter issues
3. Fixing usage of ClusterIP IP address instead of Pod IP one.
4. Fixing ExternalService using Service name for resolution instead of Pod IP.