### PR TITLE
Add test: Should Implement service.kubernetes.io/service-proxy-name

### DIFF
--- a/entities/kubernetes/error.go
+++ b/entities/kubernetes/error.go
@@ -1,0 +1,9 @@
+package kubernetes
+
+import "errors"
+
+var ErrLabelNotFound = errors.New("label not found")
+
+func IsLabelNotFound(err error) bool {
+	return err == ErrLabelNotFound
+}

--- a/entities/kubernetes/service.go
+++ b/entities/kubernetes/service.go
@@ -19,6 +19,8 @@ type ServiceBase interface {
 	Create() (*v1.Service, error)
 	Delete() error
 	GetClusterIP() string
+	GetLabel(string) (string, error)
+	SetLabel(string, string) error
 	WaitForClusterIP() (string, error)
 	WaitForNodePort() (int32, error)
 	WaitForEndpoint() (bool, error)
@@ -77,6 +79,60 @@ func (s *Service) Delete() error {
 // GetClusterIP returns the clusterIP from spec
 func (s *Service) GetClusterIP() string {
 	return s.service.Spec.ClusterIP
+}
+
+// GetLabel returns the value of label specified with key. ErrLabelNotFound if not present.
+func (s *Service) GetLabel(key string) (value string, err error) {
+	labels := s.service.ObjectMeta.Labels
+	if labels == nil {
+		return "", ErrLabelNotFound
+	}
+	value, ok := labels[key]
+	if !ok {
+		return "", ErrLabelNotFound
+	}
+	return value, nil
+}
+
+// SetLabel updates the value of label specified by key. Else if key does not exist,
+// create the key-value pair.
+func (s *Service) SetLabel(key, value string) error {
+	var err error
+	if s.service, err = s.clientSet.CoreV1().Services(s.service.Namespace).Get(context.TODO(), s.service.Name, metav1.GetOptions{}); err != nil {
+		return errors.Wrapf(err, "unable to get service %s", s.service.Name)
+	}
+	labels := s.service.ObjectMeta.Labels
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[key] = value
+	s.service.ObjectMeta.Labels = labels
+	if _, err = s.clientSet.CoreV1().Services(s.service.Namespace).Update(context.TODO(), s.service, metav1.UpdateOptions{}); err != nil {
+		return errors.Wrapf(err, "unable to update service %s", s.service.Name)
+	}
+	return nil
+}
+
+// RemoveLabel removes the label specified by key. ErrLabelNotFound if not present.
+func (s *Service) RemoveLabel(key string) error {
+	var err error
+	if s.service, err = s.clientSet.CoreV1().Services(s.service.Namespace).Get(context.TODO(), s.service.Name, metav1.GetOptions{}); err != nil {
+		return errors.Wrapf(err, "unable to get service %s", s.service.Name)
+	}
+	labels := s.service.ObjectMeta.Labels
+	if labels == nil {
+		return ErrLabelNotFound
+	}
+	if _, ok := labels[key]; !ok {
+		return ErrLabelNotFound
+	}
+	delete(labels, key)
+	s.service.ObjectMeta.Labels = labels
+	opts := metav1.UpdateOptions{}
+	if _, err := s.clientSet.CoreV1().Services(s.service.Namespace).Update(context.TODO(), s.service, opts); err != nil {
+		return errors.Wrapf(err, "unable to update service %s", s.service.Name)
+	}
+	return nil
 }
 
 // WaitForEndpoint return when all addresses are ready.

--- a/entities/kubernetes/service.go
+++ b/entities/kubernetes/service.go
@@ -21,6 +21,7 @@ type ServiceBase interface {
 	GetClusterIP() string
 	GetLabel(string) (string, error)
 	SetLabel(string, string) error
+	RemoveLabel(string) error
 	WaitForClusterIP() (string, error)
 	WaitForNodePort() (int32, error)
 	WaitForEndpoint() (bool, error)

--- a/tests/proxyname_test.go
+++ b/tests/proxyname_test.go
@@ -21,98 +21,72 @@ func mustOrFatal(err error, t *testing.T) {
 	}
 }
 
-// Pods switch to use specified set of clusterIPs,
-// either disabledClusterIPs or toggledClusterIPs for reachability access
-func podsUseClusterIPs(pods []*entities.Pod, ips []string) error {
-	if len(pods) != len(ips) {
-		return errors.New("pods number does not match the provided IP number")
+func mustNoWrong(wrongNum int, t *testing.T) {
+	if wrongNum > 0 {
+		t.Errorf("Wrong result number %d", wrongNum)
 	}
-	for i, pod := range pods {
-		pod.SetClusterIP(ips[i])
-	}
-	return nil
 }
 
-// Services switch to use specified label, with key and value
-func servicesSetLabel(services kubernetes.Services, key, value string) error {
-	for _, service := range services {
-		if err := service.SetLabel(key, value); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// Services switch to not having the label with key
-func servicesRemoveLabel(services kubernetes.Services, key string) error {
-	for _, service := range services {
-		if err := service.RemoveLabel(key); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func TestProxyName(t *testing.T) {
+func TestProxyNameLabel(t *testing.T) { // nolint
 	pods := model.AllPods()
-	var disabledServices kubernetes.Services
-	var toggledServices kubernetes.Services
 
-	var disabledClusterIPs []string
-	var toggledClusterIPs []string
+	// the pod where services under test is deployed
+	toPod := pods[0]
+
+	var disabledService kubernetes.ServiceBase
+	var toggledService kubernetes.ServiceBase
+
+	var disabledClusterIP string
+	var toggledClusterIP string
 
 	labelKey := "service.kubernetes.io/service-proxy-name"
 	labelValue := "foo-bar"
 
-	featureProxyName := features.New("ProxyName").WithLabel("type", "proxyName").
+	upReachability := matrix.NewReachability(pods, true)
+	downReachability := matrix.NewReachability(pods, true)
+	downReachability.ExpectPeer(&matrix.Peer{Namespace: namespace}, &matrix.Peer{Namespace: namespace, Pod: toPod.Name}, false)
+
+	featureProxyNameLabel := features.New("ProxyNameLabel").WithLabel("type", "ProxyNameLabel").
 		Setup(func(_ context.Context, t *testing.T, _ *envconf.Config) context.Context {
-			for _, pod := range pods {
-				var (
-					disabledClusterIP string
-					toggledClusterIP  string
-					err               error
-				)
-				// create a disabled service labeled with service-proxy-name
-				var serviceDisabled kubernetes.ServiceBase = kubernetes.NewService(cs, pod.ClusterIPService())
-				if _, err := serviceDisabled.Create(); err != nil {
-					t.Fatal()
-				}
-				disabledServices = append(disabledServices, serviceDisabled.(*kubernetes.Service))
+			var err error
 
-				// create a service without the label, but will be toggled later
-				var serviceToggled kubernetes.ServiceBase = kubernetes.NewService(cs, pod.ClusterIPService())
-				if _, err := serviceToggled.Create(); err != nil {
-					t.Fatal()
-				}
-				toggledServices = append(toggledServices, serviceToggled.(*kubernetes.Service))
-
-				// wait for the disabled service
-				if result, err := serviceDisabled.WaitForEndpoint(); err != nil || !result {
-					t.Fatal(errors.New("no endpoint available"))
-				}
-				if disabledClusterIP, err = serviceDisabled.WaitForClusterIP(); err != nil || disabledClusterIP == "" {
-					t.Fatal(errors.New("no cluster IP available"))
-				}
-
-				// wait for the toggled service
-				if result, err := serviceToggled.WaitForEndpoint(); err != nil || !result {
-					t.Fatal(errors.New("no endpoint available"))
-				}
-				if toggledClusterIP, err = serviceToggled.WaitForClusterIP(); err != nil || toggledClusterIP == "" {
-					t.Fatal(errors.New("no cluster IP available"))
-				}
-
-				disabledClusterIPs = append(disabledClusterIPs, disabledClusterIP)
-				toggledClusterIPs = append(toggledClusterIPs, toggledClusterIP)
-
-				// label the disabled service
-				mustOrFatal(serviceDisabled.SetLabel(labelKey, labelValue), t)
+			// create a disabled service labeled with service-proxy-name
+			disabledService = kubernetes.NewService(cs, toPod.ClusterIPService())
+			if _, err := disabledService.Create(); err != nil {
+				t.Fatal()
 			}
+
+			// create a service without the label, but will be toggled later
+			toggledService = kubernetes.NewService(cs, toPod.ClusterIPService())
+			if _, err := toggledService.Create(); err != nil {
+				t.Fatal()
+			}
+
+			// wait for the disabled service
+			if result, err := disabledService.WaitForEndpoint(); err != nil || !result {
+				t.Fatal(errors.New("no endpoint available"))
+			}
+
+			if disabledClusterIP, err = disabledService.WaitForClusterIP(); err != nil || disabledClusterIP == "" {
+				t.Fatal(errors.New("no cluster IP available"))
+			}
+
+			// wait for the toggled service
+			if result, err := toggledService.WaitForEndpoint(); err != nil || !result {
+				t.Fatal(errors.New("no endpoint available"))
+			}
+
+			if toggledClusterIP, err = toggledService.WaitForClusterIP(); err != nil || toggledClusterIP == "" {
+				t.Fatal(errors.New("no cluster IP available"))
+			}
+
+			// label the disabled service
+			mustOrFatal(disabledService.SetLabel(labelKey, labelValue), t)
 			return ctx
 		}).
 		Teardown(func(context.Context, *testing.T, *envconf.Config) context.Context {
-			for _, services := range []kubernetes.Services{disabledServices, toggledServices} {
-				if err := services.Delete(); err != nil {
+			for _, service := range []kubernetes.ServiceBase{disabledService, toggledService} {
+				if err := service.Delete(); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -120,46 +94,47 @@ func TestProxyName(t *testing.T) {
 		}).
 		Assess("should implement service.kubernetes.io/service-proxy-name", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			ma.Logger.Info("verify the toggledServices are up.")
-			mustOrFatal(podsUseClusterIPs(pods, toggledClusterIPs), t)
-			matrix.ValidateOrFail(ma, model, &matrix.TestCase{
-				ToPort: 80, Protocol: v1.ProtocolTCP, Reachability: matrix.NewReachability(pods, true),
+			toPod.SetClusterIP(toggledClusterIP)
+			mustNoWrong(matrix.ValidateOrFail(ma, model, &matrix.TestCase{
+				ToPort: 80, Protocol: v1.ProtocolTCP, Reachability: upReachability,
 				ServiceType: entities.ClusterIP,
-			}, false)
+			}, false), t)
 
 			ma.Logger.Info("verify the disabledServices are not up.")
-			mustOrFatal(podsUseClusterIPs(pods, disabledClusterIPs), t)
-			matrix.ValidateOrFail(ma, model, &matrix.TestCase{
-				ToPort: 80, Protocol: v1.ProtocolTCP, Reachability: matrix.NewReachability(pods, false),
+			toPod.SetClusterIP(disabledClusterIP)
+			mustNoWrong(matrix.ValidateOrFail(ma, model, &matrix.TestCase{
+				ToPort: 80, Protocol: v1.ProtocolTCP, Reachability: downReachability,
 				ServiceType: entities.ClusterIP,
-			}, false)
+			}, false), t)
 
 			ma.Logger.Info("add service-proxy-name label.")
-			mustOrFatal(servicesSetLabel(toggledServices, labelKey, labelValue), t)
+			mustOrFatal(toggledService.SetLabel(labelKey, labelValue), t)
 
 			ma.Logger.Info("verify the toggledServices are not up.")
-			mustOrFatal(podsUseClusterIPs(pods, toggledClusterIPs), t)
-			matrix.ValidateOrFail(ma, model, &matrix.TestCase{
-				ToPort: 80, Protocol: v1.ProtocolTCP, Reachability: matrix.NewReachability(pods, false),
+			toPod.SetClusterIP(toggledClusterIP)
+			mustNoWrong(matrix.ValidateOrFail(ma, model, &matrix.TestCase{
+				ToPort: 80, Protocol: v1.ProtocolTCP, Reachability: downReachability,
 				ServiceType: entities.ClusterIP,
-			}, false)
+			}, false), t)
 
 			ma.Logger.Info("remove service-proxy-name label.")
-			mustOrFatal(servicesRemoveLabel(toggledServices, labelKey), t)
+			mustOrFatal(toggledService.RemoveLabel(labelKey), t)
 
 			ma.Logger.Info("verify the toggledServices are up again.")
-			matrix.ValidateOrFail(ma, model, &matrix.TestCase{
-				ToPort: 80, Protocol: v1.ProtocolTCP, Reachability: matrix.NewReachability(pods, true),
+			mustNoWrong(matrix.ValidateOrFail(ma, model, &matrix.TestCase{
+				ToPort: 80, Protocol: v1.ProtocolTCP, Reachability: upReachability,
 				ServiceType: entities.ClusterIP,
-			}, false)
+			}, false), t)
 
 			ma.Logger.Info("verify the disabledServices are still not up.")
-			mustOrFatal(podsUseClusterIPs(pods, disabledClusterIPs), t)
-			matrix.ValidateOrFail(ma, model, &matrix.TestCase{
-				ToPort: 80, Protocol: v1.ProtocolTCP, Reachability: matrix.NewReachability(pods, false),
+			toPod.SetClusterIP(disabledClusterIP)
+			mustNoWrong(matrix.ValidateOrFail(ma, model, &matrix.TestCase{
+				ToPort: 80, Protocol: v1.ProtocolTCP, Reachability: downReachability,
 				ServiceType: entities.ClusterIP,
-			}, false)
+			}, false), t)
 			return ctx
 		}).
 		Feature()
-	testenv.Test(t, featureProxyName)
+
+	testenv.Test(t, featureProxyNameLabel)
 }

--- a/tests/proxyname_test.go
+++ b/tests/proxyname_test.go
@@ -1,0 +1,165 @@
+package suites
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	"github.com/k8sbykeshed/k8s-service-lb-validator/entities"
+	"github.com/k8sbykeshed/k8s-service-lb-validator/entities/kubernetes"
+	"github.com/k8sbykeshed/k8s-service-lb-validator/matrix"
+)
+
+func mustOrFatal(err error, t *testing.T) {
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Pods switch to use specified set of clusterIPs,
+// either disabledClusterIPs or toggledClusterIPs for reachability access
+func podsUseClusterIPs(pods []*entities.Pod, ips []string) error {
+	if len(pods) != len(ips) {
+		return errors.New("pods number does not match the provided IP number")
+	}
+	for i, pod := range pods {
+		pod.SetClusterIP(ips[i])
+	}
+	return nil
+}
+
+// Services switch to use specified label, with key and value
+func servicesSetLabel(services kubernetes.Services, key, value string) error {
+	for _, service := range services {
+		if err := service.SetLabel(key, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Services switch to not having the label with key
+func servicesRemoveLabel(services kubernetes.Services, key string) error {
+	for _, service := range services {
+		if err := service.RemoveLabel(key); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func TestProxyName(t *testing.T) {
+	pods := model.AllPods()
+	var disabledServices kubernetes.Services
+	var toggledServices kubernetes.Services
+
+	var disabledClusterIPs []string
+	var toggledClusterIPs []string
+
+	labelKey := "service.kubernetes.io/service-proxy-name"
+	labelValue := "foo-bar"
+
+	featureProxyName := features.New("ProxyName").WithLabel("type", "proxyName").
+		Setup(func(_ context.Context, t *testing.T, _ *envconf.Config) context.Context {
+			for _, pod := range pods {
+				var (
+					disabledClusterIP string
+					toggledClusterIP  string
+					err               error
+				)
+				// create a disabled service labeled with service-proxy-name
+				var serviceDisabled kubernetes.ServiceBase = kubernetes.NewService(cs, pod.ClusterIPService())
+				if _, err := serviceDisabled.Create(); err != nil {
+					t.Fatal()
+				}
+				disabledServices = append(disabledServices, serviceDisabled.(*kubernetes.Service))
+
+				// create a service without the label, but will be toggled later
+				var serviceToggled kubernetes.ServiceBase = kubernetes.NewService(cs, pod.ClusterIPService())
+				if _, err := serviceToggled.Create(); err != nil {
+					t.Fatal()
+				}
+				toggledServices = append(toggledServices, serviceToggled.(*kubernetes.Service))
+
+				// wait for the disabled service
+				if result, err := serviceDisabled.WaitForEndpoint(); err != nil || !result {
+					t.Fatal(errors.New("no endpoint available"))
+				}
+				if disabledClusterIP, err = serviceDisabled.WaitForClusterIP(); err != nil || disabledClusterIP == "" {
+					t.Fatal(errors.New("no cluster IP available"))
+				}
+
+				// wait for the toggled service
+				if result, err := serviceToggled.WaitForEndpoint(); err != nil || !result {
+					t.Fatal(errors.New("no endpoint available"))
+				}
+				if toggledClusterIP, err = serviceToggled.WaitForClusterIP(); err != nil || toggledClusterIP == "" {
+					t.Fatal(errors.New("no cluster IP available"))
+				}
+
+				disabledClusterIPs = append(disabledClusterIPs, disabledClusterIP)
+				toggledClusterIPs = append(toggledClusterIPs, toggledClusterIP)
+
+				// label the disabled service
+				mustOrFatal(serviceDisabled.SetLabel(labelKey, labelValue), t)
+			}
+			return ctx
+		}).
+		Teardown(func(context.Context, *testing.T, *envconf.Config) context.Context {
+			for _, services := range []kubernetes.Services{disabledServices, toggledServices} {
+				if err := services.Delete(); err != nil {
+					t.Fatal(err)
+				}
+			}
+			return ctx
+		}).
+		Assess("should implement service.kubernetes.io/service-proxy-name", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			ma.Logger.Info("verify the toggledServices are up.")
+			mustOrFatal(podsUseClusterIPs(pods, toggledClusterIPs), t)
+			matrix.ValidateOrFail(ma, model, &matrix.TestCase{
+				ToPort: 80, Protocol: v1.ProtocolTCP, Reachability: matrix.NewReachability(pods, true),
+				ServiceType: entities.ClusterIP,
+			}, false)
+
+			ma.Logger.Info("verify the disabledServices are not up.")
+			mustOrFatal(podsUseClusterIPs(pods, disabledClusterIPs), t)
+			matrix.ValidateOrFail(ma, model, &matrix.TestCase{
+				ToPort: 80, Protocol: v1.ProtocolTCP, Reachability: matrix.NewReachability(pods, false),
+				ServiceType: entities.ClusterIP,
+			}, false)
+
+			ma.Logger.Info("add service-proxy-name label.")
+			mustOrFatal(servicesSetLabel(toggledServices, labelKey, labelValue), t)
+
+			ma.Logger.Info("verify the toggledServices are not up.")
+			mustOrFatal(podsUseClusterIPs(pods, toggledClusterIPs), t)
+			matrix.ValidateOrFail(ma, model, &matrix.TestCase{
+				ToPort: 80, Protocol: v1.ProtocolTCP, Reachability: matrix.NewReachability(pods, false),
+				ServiceType: entities.ClusterIP,
+			}, false)
+
+			ma.Logger.Info("remove service-proxy-name label.")
+			mustOrFatal(servicesRemoveLabel(toggledServices, labelKey), t)
+
+			ma.Logger.Info("verify the toggledServices are up again.")
+			matrix.ValidateOrFail(ma, model, &matrix.TestCase{
+				ToPort: 80, Protocol: v1.ProtocolTCP, Reachability: matrix.NewReachability(pods, true),
+				ServiceType: entities.ClusterIP,
+			}, false)
+
+			ma.Logger.Info("verify the disabledServices are still not up.")
+			mustOrFatal(podsUseClusterIPs(pods, disabledClusterIPs), t)
+			matrix.ValidateOrFail(ma, model, &matrix.TestCase{
+				ToPort: 80, Protocol: v1.ProtocolTCP, Reachability: matrix.NewReachability(pods, false),
+				ServiceType: entities.ClusterIP,
+			}, false)
+			return ctx
+		}).
+		Feature()
+	testenv.Test(t, featureProxyName)
+}


### PR DESCRIPTION
E2E tests for https://github.com/kubernetes/kubernetes/blob/da707b6133ff0c66dc4d24295374e7e5de8852f5/test/e2e/network/service.go#L1889

```
2021-11-28T03:00:12.536-0800	info	Tests passed, validation succeeded!
--- PASS: TestProxyName (124.79s)
    --- PASS: TestProxyName/ProxyName (124.79s)
        --- PASS: TestProxyName/ProxyName/should_implement_service.kubernetes.io/service-proxy-name (123.29s)
```